### PR TITLE
fix: join both metatable object types

### DIFF
--- a/core/debug.d.ts
+++ b/core/debug.d.ts
@@ -192,7 +192,10 @@ declare namespace debug {
    * Sets the metatable for the given value to the given table (which can be
    * nil). Returns value.
    */
-  function setmetatable<T>(value: T, table: LuaMetatable<T> | null | undefined): T;
+  function setmetatable<T, TIndex>(
+    value: T,
+    table: LuaMetatable<T & TIndex, TIndex> | null | undefined,
+  ): T & TIndex;
 
   /**
    * This function assigns the value value to the upvalue with index up of the

--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -116,7 +116,7 @@ declare function error(message: string, level?: number): never;
  * metatable has a __metatable field, returns the associated value. Otherwise,
  * returns the metatable of the given object.
  */
-declare function getmetatable<T extends object>(object: T): LuaMetatable<T, object> | undefined;
+declare function getmetatable<T extends object>(object: T): LuaMetatable<T> | undefined;
 
 /**
  * Returns three values (an iterator function, the table t, and 0) so that the

--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -116,7 +116,7 @@ declare function error(message: string, level?: number): never;
  * metatable has a __metatable field, returns the associated value. Otherwise,
  * returns the metatable of the given object.
  */
-declare function getmetatable<T extends object>(object: T): LuaMetatable<T> | undefined;
+declare function getmetatable<T extends object>(object: T): LuaMetatable<T, object> | undefined;
 
 /**
  * Returns three values (an iterator function, the table t, and 0) so that the
@@ -247,7 +247,7 @@ declare function select<T>(index: '#', ...args: T[]): number;
  */
 declare function setmetatable<T extends object, M extends object>(
   table: T,
-  metatable: LuaMetatable<M> | null | undefined,
+  metatable: LuaMetatable<T & M, M> | null | undefined,
 ): T & M;
 
 /**

--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -245,10 +245,10 @@ declare function select<T>(index: '#', ...args: T[]): number;
  *
  * This function returns table.
  */
-declare function setmetatable<T extends object>(
+declare function setmetatable<T extends object, M extends object>(
   table: T,
-  metatable: LuaMetatable<T> | null | undefined,
-): T;
+  metatable: LuaMetatable<M> | null | undefined,
+): T & M;
 
 /**
  * When called with no base, tonumber tries to convert its argument to a number.

--- a/core/global.d.ts
+++ b/core/global.d.ts
@@ -245,10 +245,10 @@ declare function select<T>(index: '#', ...args: T[]): number;
  *
  * This function returns table.
  */
-declare function setmetatable<T extends object, M extends object>(
+declare function setmetatable<T extends object, TIndex extends object>(
   table: T,
-  metatable: LuaMetatable<T & M, M> | null | undefined,
-): T & M;
+  metatable: LuaMetatable<T & TIndex, TIndex> | null | undefined,
+): T & TIndex;
 
 /**
  * When called with no base, tonumber tries to convert its argument to a number.

--- a/core/metatable.d.ts
+++ b/core/metatable.d.ts
@@ -1,6 +1,10 @@
 // Based on https://www.lua.org/manual/5.3/manual.html#2.4
 
-interface LuaMetatable<T extends object> {
+/**
+ * @typeparam T The prototype object and the metatable.
+ * @typeparam M This metatable.
+ */
+interface LuaMetatable<T extends object, M extends object> {
   /**
    * the addition (+) operation. If any operand for an addition is not a number
    * (nor a string coercible to a number), Lua will try to call a metamethod.
@@ -102,7 +106,7 @@ interface LuaMetatable<T extends object> {
    * this table with key. (This indexing is regular, not raw, and therefore can
    * trigger another metamethod.)
    */
-  __index?: T | ((this: T, key: any, value: any) => any);
+  __index?: M | ((this: T, key: any, value: any) => any);
 
   /**
    * The indexing assignment table[key] = value. Like the index event, this

--- a/core/metatable.d.ts
+++ b/core/metatable.d.ts
@@ -1,6 +1,6 @@
 // Based on https://www.lua.org/manual/5.3/manual.html#2.4
 
-interface LuaMetatable<T> {
+interface LuaMetatable<T extends object> {
   /**
    * the addition (+) operation. If any operand for an addition is not a number
    * (nor a string coercible to a number), Lua will try to call a metamethod.
@@ -102,7 +102,7 @@ interface LuaMetatable<T> {
    * this table with key. (This indexing is regular, not raw, and therefore can
    * trigger another metamethod.)
    */
-  __index?: object | ((this: T, key: any, value: any) => any);
+  __index?: T | ((this: T, key: any, value: any) => any);
 
   /**
    * The indexing assignment table[key] = value. Like the index event, this

--- a/core/metatable.d.ts
+++ b/core/metatable.d.ts
@@ -1,10 +1,6 @@
 // Based on https://www.lua.org/manual/5.3/manual.html#2.4
 
-/**
- * @typeparam T The prototype object and the metatable.
- * @typeparam M This metatable.
- */
-interface LuaMetatable<T extends object, M extends object = object> {
+interface LuaMetatable<T extends object, TIndex extends object = object> {
   /**
    * the addition (+) operation. If any operand for an addition is not a number
    * (nor a string coercible to a number), Lua will try to call a metamethod.
@@ -106,7 +102,7 @@ interface LuaMetatable<T extends object, M extends object = object> {
    * this table with key. (This indexing is regular, not raw, and therefore can
    * trigger another metamethod.)
    */
-  __index?: M | ((this: T, key: any, value: any) => any);
+  __index?: TIndex | ((this: T, key: any, value: any) => any);
 
   /**
    * The indexing assignment table[key] = value. Like the index event, this

--- a/core/metatable.d.ts
+++ b/core/metatable.d.ts
@@ -4,7 +4,7 @@
  * @typeparam T The prototype object and the metatable.
  * @typeparam M This metatable.
  */
-interface LuaMetatable<T extends object, M extends object> {
+interface LuaMetatable<T extends object, M extends object = object> {
   /**
    * the addition (+) operation. If any operand for an addition is not a number
    * (nor a string coercible to a number), Lua will try to call a metamethod.

--- a/core/metatable.d.ts
+++ b/core/metatable.d.ts
@@ -1,6 +1,6 @@
 // Based on https://www.lua.org/manual/5.3/manual.html#2.4
 
-interface LuaMetatable<T extends object, TIndex extends object = object> {
+interface LuaMetatable<T, TIndex = object> {
   /**
    * the addition (+) operation. If any operand for an addition is not a number
    * (nor a string coercible to a number), Lua will try to call a metamethod.


### PR DESCRIPTION
`setmetatable`'s typings ignore the `__index` of the metatable which can reveal a better return type.

```ts
import "./jit";

const A: { a: 1 } = { a: 1 };
const B: { b: 2 } = { b: 2 };

// lua-types says a is {}
// a is actually { a: 1 }
const a = setmetatable({}, { __index: A });

// lua-types says ab is { a: 1 }
// ab is actually { a: 1, b: 2 }
const ab = setmetatable(A, { __index: B });
```