### PR TITLE
Correct the return type of math.modf to a tuple of integral- and fractional part

### DIFF
--- a/core/math.d.ts
+++ b/core/math.d.ts
@@ -77,8 +77,9 @@ declare namespace math {
   /**
    * Returns the integral part of x and the fractional part of x. Its second
    * result is always a float.
+   * @tupleReturn
    */
-  function modf(x: number): number;
+  function modf(x: number): [number, number];
 
   /**
    * The value of π.


### PR DESCRIPTION
As the comment for `modf` states, it returns two parts and uses like `const [integral, fractional] = math.modf(x)` are now possible.