### PR TITLE
Correct the type signature of string.find

### DIFF
--- a/core/string.d.ts
+++ b/core/string.d.ts
@@ -57,7 +57,12 @@ declare namespace string {
    * are also returned, after the two indices.
    * @tupleReturn
    */
-  function find(s: string, pattern: string, init?: number, plain?: boolean): [number, number] | [];
+  function find(
+    s: string,
+    pattern: string,
+    init?: number,
+    plain?: boolean,
+  ): [number, number, ...string[]] | [];
 
   /**
    * Returns a formatted version of its variable number of arguments following


### PR DESCRIPTION
`string.find` may accept capture groups and return a variable length string
array after the two indices of a match.